### PR TITLE
KTO-40: Parannettu kk-koulutusten nimipäättelyä.

### DIFF
--- a/src/konfo_indeksoija_service/converter/koulutus_converter.clj
+++ b/src/konfo_indeksoija_service/converter/koulutus_converter.clj
@@ -23,6 +23,9 @@
              {}
              value))
 
+(defn- getNimiFromTekstis [dto]
+  (get-in dto [:koulutusohjelma :tekstis]))
+
 (defn- kielivalikoima
   [value]
   (reduce-kv #(assoc %1 %2 (extract-koodi-list %3 [:meta]))
@@ -122,4 +125,7 @@
 ;; Loops key-value map and transforms the value
 (defn convert
   [dto]
-  (into {} (for [[k v] dto] [k ((k map-field-to-converter) v)])))
+  (let [raw-res (into {} (for [[k v] dto] [k ((k map-field-to-converter) v)]))]
+    (if (nil? (:nimi raw-res))
+      (assoc raw-res :nimi (getNimiFromTekstis dto))
+      raw-res)))

--- a/src/konfo_indeksoija_service/converter/koulutus_search_data_appender.clj
+++ b/src/konfo_indeksoija_service/converter/koulutus_search_data_appender.clj
@@ -61,10 +61,14 @@
 (defn find-koulutus-nimi [koulutus hakukohteet tyyppi]
   (if (= "lk" tyyppi)
     (:nimi (:koulutusohjelma koulutus))
-    (if-let [koulutuskoodi (:koulutuskoodi koulutus)]
-      (:nimi koulutuskoodi)
-      (if-let [hakukohde (first hakukohteet)]                   ;TODO -> miltä hakukohteelta haetaan?
-        (:nimi hakukohde)))))
+    (if (not (empty? (:nimi koulutus)))
+      (:nimi koulutus)
+      (if-let [koulutuskoodi (:koulutuskoodi koulutus)]
+        (:nimi koulutuskoodi)
+        (if-let [hakukohde (first hakukohteet)]                   ;TODO -> miltä hakukohteelta haetaan?
+          (:nimi hakukohde))
+      ))
+    ))
 
 (defn- find-koulutus-tyyppi [koulutus]
   (let [tyyppi (koulutustyyppi-uri-to-tyyppi (get-in koulutus [:koulutustyyppi :uri]))]


### PR DESCRIPTION
Haetaan koulutuksen nimeksi koulutusohjelma -> tekstis, jos sellainen on määritelty.