### PR TITLE
Kto 127

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ deploy:
     script: lein deploy
     skip_cleanup: true
     on:
-      branch: master
+      branch: KTO-127
   - provider: script
     script: ./ci-tools/build/upload-image.sh ${ARTIFACT_NAME}
     on:

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (cemerick.pomegranate.aether/register-wagon-factory!
   "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
-(defproject konfo-indeksoija-service "0.1.0-SNAPSHOT"
+(defproject konfo-indeksoija-service "0.1.1-SNAPSHOT"
   :description "FIXME: write description"
   :repositories [["releases" {:url "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local"
                               :username :env/artifactory_username

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.clojure/algo.generic "0.1.3"]
                  ;Elasticsearch + s3
                  [oph/clj-elasticsearch "0.2.0-SNAPSHOT"]
-                 [oph/clj-s3 "0.2.0-SNAPSHOT"]
+                 [oph/clj-s3 "0.2.2-SNAPSHOT"]
                  ;;Logging
                  [oph/clj-log "0.2.0-SNAPSHOT"]
                  [org.clojure/tools.logging "0.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (cemerick.pomegranate.aether/register-wagon-factory!
   "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
-(defproject konfo-indeksoija-service "0.1.1-SNAPSHOT"
+(defproject konfo-indeksoija-service "0.1.2-SNAPSHOT"
   :description "FIXME: write description"
   :repositories [["releases" {:url "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local"
                               :username :env/artifactory_username

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (cemerick.pomegranate.aether/register-wagon-factory!
   "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
-(defproject konfo-indeksoija-service "0.1.2-SNAPSHOT"
+(defproject konfo-indeksoija-service "0.1.3-SNAPSHOT"
   :description "FIXME: write description"
   :repositories [["releases" {:url "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local"
                               :username :env/artifactory_username

--- a/src/konfo_indeksoija_service/api.clj
+++ b/src/konfo_indeksoija_service/api.clj
@@ -34,7 +34,7 @@
   (if (and (admin/check-elastic-status)
            (admin/initialize-indices))
     (do
-      (comment j/start-indexer-job)
+      (j/start-indexer-job)
       (qjob/start-handle-dlq-job)
       (q/index-from-queue!))
     (do
@@ -134,8 +134,16 @@
      (context "/queue" []
        :tags ["queue"]
        (GET "/all" []
-         :summary "Indeksoi kaikki koulutukset, hakukohteet, haut ja organisaatiot."
+         :summary "Lisää kaikki vanhan tarjonnan koulutukset, haut ja hakukohteet sekä organisaatiot ja eperusteet indeksoitavien listalle."
          (ok {:result (queue/queue-all)}))
+
+       (GET "/eperusteet" []
+         :summary "Lisää kaikki eperusteet indeksoitavien listalle"
+         (ok {:result (queue/queue-all-eperusteet)}))
+
+       (GET "/eperusteet" []
+         :summary "Lisää kaikki organisaatiot indeksoitavien listalle"
+         (ok {:result (queue/queue-all-organisaatiot)}))
 
        (GET "/koulutus" []
          :summary "Lisää koulutuksen indeksoitavien listalle."

--- a/src/konfo_indeksoija_service/elastic/settings.clj
+++ b/src/konfo_indeksoija_service/elastic/settings.clj
@@ -3,7 +3,7 @@
 (def index-settings
   {:index.mapping.total_fields.limit 2000
    :analysis {:filter {:edge_ngram_long_words {:type "edge_ngram"
-                                               :min_gram "4"
+                                               :min_gram "6"
                                                :max_gram "12"}
                        :edge_gram_compound_words {:type "ngram"
                                                   :min_gram "6"
@@ -121,6 +121,10 @@
   {:dynamic_templates [{:nested {:match "toteutukset"
                                  :match_mapping_type "object"
                                  :mapping { :type "nested" }}}
+                       {:hakuOnKaynnissa {:match "hakuOnKaynnissa"
+                                          :match_mapping_type "object"
+                                          :mapping {:type "date_range"
+                                                    :format "yyyy-MM-dd'T'HH:mm"}}}
                        {:fi {:match "fi"
                              :match_mapping_type "string"
                              :mapping {:type "text"

--- a/src/konfo_indeksoija_service/indexer/job.clj
+++ b/src/konfo_indeksoija_service/indexer/job.clj
@@ -35,9 +35,10 @@
           changes-since (clojure.set/union organisaatio-changes eperuste-changes)] ;tarjonta-changes
       (when-not (nil? changes-since)
         (log/info "Fetched last-modified since" (to-date-string last-modified)", containing" (count changes-since) "changes.")
-        (let [related-koulutus (flatten (pmap tarjonta/get-related-koulutus changes-since))
-              last-modified-with-related-koulutus (remove nil? (clojure.set/union changes-since related-koulutus))]
-          (if-not (empty? related-koulutus)
+        (let [                                              ;related-koulutus (flatten (pmap tarjonta/get-related-koulutus changes-since))
+              last-modified-with-related-koulutus (remove nil? changes-since ;(clojure.set/union changes-since related-koulutus)
+                                                          )]
+          (comment if-not (empty? related-koulutus)
             (log/info "Fetched" (count related-koulutus) "related koulutukses for previous changes"))
           (upsert-to-queue last-modified-with-related-koulutus)
           (set-last-index-time now)))

--- a/src/konfo_indeksoija_service/indexer/job.clj
+++ b/src/konfo_indeksoija_service/indexer/job.clj
@@ -51,7 +51,7 @@
               (j/of-type indexing-job)
               (j/with-identity "jobs.index.1"))
          trigger (t/build
-                  (t/with-identity (t/key "cron-trigger"))
+                  (t/with-identity (t/key "index-cron-trigger"))
                   (t/start-now)
                   (t/with-schedule
                    (schedule (cron-schedule cron-string))))]

--- a/src/konfo_indeksoija_service/indexer/job.clj
+++ b/src/konfo_indeksoija_service/indexer/job.clj
@@ -29,10 +29,10 @@
    (wait-for-elastic-lock
     (let [now (System/currentTimeMillis)
           last-modified (get-last-index-time)
-          tarjonta-changes (tarjonta/get-last-modified last-modified)
+          ;tarjonta-changes (tarjonta/get-last-modified last-modified)
           organisaatio-changes (organisaatio/find-last-changes last-modified)
           eperuste-changes (eperuste/find-changes last-modified)
-          changes-since (clojure.set/union tarjonta-changes organisaatio-changes eperuste-changes)]
+          changes-since (clojure.set/union organisaatio-changes eperuste-changes)] ;tarjonta-changes
       (when-not (nil? changes-since)
         (log/info "Fetched last-modified since" (to-date-string last-modified)", containing" (count changes-since) "changes.")
         (let [related-koulutus (flatten (pmap tarjonta/get-related-koulutus changes-since))

--- a/src/konfo_indeksoija_service/indexer/job.clj
+++ b/src/konfo_indeksoija_service/indexer/job.clj
@@ -40,8 +40,8 @@
           (if-not (empty? related-koulutus)
             (log/info "Fetched" (count related-koulutus) "related koulutukses for previous changes"))
           (upsert-to-queue last-modified-with-related-koulutus)
-          (set-last-index-time now)
-          (do-index)))))))
+          (set-last-index-time now)))
+      (do-index)))))
 
 (defn start-indexer-job
   ([] (start-indexer-job (:cron-string env)))

--- a/src/konfo_indeksoija_service/indexer/queue.clj
+++ b/src/konfo_indeksoija_service/indexer/queue.clj
@@ -14,7 +14,7 @@
 
 (defn queue-all
   []
-  (log/info "Tyhjennetään indeksointijono ja uudelleenindeksoidaan kaikki data Tarjonnasta ja organisaatiopalvelusta.")
+  (log/info "Tyhjennetään indeksointijono ja uudelleenindeksoidaan kaikki data Tarjonnasta, eperusteista ja organisaatiopalvelusta.")
   (reset-queue)
   (let [tarjonta-docs (tarjonta-client/find-all-tarjonta-docs)
         organisaatio-docs (organisaatio-client/find-docs nil)
@@ -22,6 +22,18 @@
         docs (clojure.set/union tarjonta-docs organisaatio-docs eperusteet-docs)]
     (log/info "Saving" (count docs) "items to index-queue" (flatten (for [[k v] (group-by :type docs)] [(count v) k]) ))
     (upsert-to-queue docs)))
+
+(defn queue-all-eperusteet
+  []
+  (let [eperusteet-docs (eperusteet-client/find-all)]
+    (log/info "Lisätään indeksoijan jonoon " (count eperusteet-docs) " eperustetta")
+    (upsert-to-queue eperusteet-docs)))
+
+(defn queue-all-organisaatiot
+  []
+  (let [organisaatio-docs (organisaatio-client/find-docs nil)]
+    (log/info "Lisätään indeksoijan jonoon " (count organisaatio-docs) " organisaatiota")
+    (upsert-to-queue organisaatio-docs)))
 
 (defn queue
   [index oid]

--- a/src/konfo_indeksoija_service/kouta/tools/hakuaika.clj
+++ b/src/konfo_indeksoija_service/kouta/tools/hakuaika.clj
@@ -1,0 +1,41 @@
+(ns konfo-indeksoija-service.kouta.tools.hakuaika)
+
+(defn- ->to-distinct-vec
+  [coll]
+  (vec (set coll)))
+
+(defn- ->hakuaika
+  [hakuaika]
+  { :gte (:alkaa hakuaika)
+    :lt  (:paattyy hakuaika) })
+
+(defn- kaytetaanHaunAikatauluaHakukohteessa?
+  [hakukohde]
+  (true? (:kaytetaanHaunAikataulua hakukohde)))
+
+(defn- kaytetaanHaunAikatauluaHaussa?
+  [haku]
+  (or (empty? (:hakukohteet haku))
+      (some kaytetaanHaunAikatauluaHakukohteessa? (:hakukohteet haku))))
+
+(defn- haun-hakuajat
+  [haku]
+  (when (kaytetaanHaunAikatauluaHaussa? haku)
+    (map ->hakuaika (:hakuajat haku))))
+
+(defn- hakukohteet-hakuajat
+  [hakukohde]
+  (when (not (kaytetaanHaunAikatauluaHakukohteessa? hakukohde))
+    (map ->hakuaika (:hakuajat hakukohde))))
+
+(defn- hakukohteiden-hakuajat
+  [haku]
+  (apply concat (map hakukohteet-hakuajat (:hakukohteet haku))))
+
+(defn- ->hakuajat
+  [haku]
+  (concat (haun-hakuajat haku) (hakukohteiden-hakuajat haku)))
+
+(defn ->real-hakuajat
+  [hakutieto]
+  (->to-distinct-vec (apply concat (map ->hakuajat (:haut hakutieto)))))

--- a/src/konfo_indeksoija_service/queue/job.clj
+++ b/src/konfo_indeksoija_service/queue/job.clj
@@ -17,7 +17,7 @@
                (j/of-type handle-dlq-job)
                (j/with-identity "jobs.DLQ.1"))
          trigger (t/build
-                   (t/with-identity (t/key "cron-trigger"))
+                   (t/with-identity (t/key "dlq-cron-trigger"))
                    (t/start-now)
                    (t/with-schedule
                       (schedule (cron-schedule cron-string))))]

--- a/test/konfo_indeksoija_service/fixture/kouta_indexer_fixture.clj
+++ b/test/konfo_indeksoija_service/fixture/kouta_indexer_fixture.clj
@@ -135,6 +135,15 @@
   (tools/delete-index konfo-indeksoija-service.kouta.valintaperuste/index-name)
   (tools/delete-index konfo-indeksoija-service.kouta.koulutus-search/index-name))
 
+(defn refresh-indices
+  []
+  (tools/refresh-index konfo-indeksoija-service.kouta.koulutus/index-name)
+  (tools/refresh-index konfo-indeksoija-service.kouta.toteutus/index-name)
+  (tools/refresh-index konfo-indeksoija-service.kouta.haku/index-name)
+  (tools/refresh-index konfo-indeksoija-service.kouta.hakukohde/index-name)
+  (tools/refresh-index konfo-indeksoija-service.kouta.valintaperuste/index-name)
+  (tools/refresh-index konfo-indeksoija-service.kouta.koulutus-search/index-name))
+
 (defn reset-mocks
   []
   (.reset KoutaFixture))
@@ -202,26 +211,20 @@
      (do ~@body)))
 
 (defn index-oids-with-related-indices
-  ([oids wait-in-millis]
-   (with-mocked-indexing
-    (indexer/index-oids oids))
-   (Thread/sleep wait-in-millis))
-  ([oids]
-   (index-oids-with-related-indices oids 1000)))
+  [oids]
+  (with-mocked-indexing
+   (indexer/index-oids oids))
+  (refresh-indices))
 
 (defn index-oids-without-related-indices
-  ([oids wait-in-millis]
-    (with-mocked-indexing
-      (with-redefs [konfo-indeksoija-service.rest.kouta/get-last-modified (fn [x] oids)]
-        (indexer/index-all)))
-   (Thread/sleep wait-in-millis))
-  ([oids]
-   (index-oids-without-related-indices oids 1000)))
+  [oids]
+  (with-mocked-indexing
+    (with-redefs [konfo-indeksoija-service.rest.kouta/get-last-modified (fn [x] oids)]
+      (indexer/index-all)))
+  (refresh-indices))
 
 (defn index-all
-  ([wait-in-millis]
-   (with-mocked-indexing
-    (indexer/index-all))
-    (Thread/sleep wait-in-millis))
-  ([]
-   (index-all 1000)))
+  []
+  (with-mocked-indexing
+   (indexer/index-all))
+  (refresh-indices))

--- a/test/konfo_indeksoija_service/indexer_test.clj
+++ b/test/konfo_indeksoija_service/indexer_test.clj
@@ -67,7 +67,7 @@
           (< (:timestamp hk2-res) (:timestamp (docs/get-hakukohde hk2-oid))) => true
           (< (:timestamp k1-res) (:timestamp (docs/get-koulutus k1-oid))) => true))))
 
-  (fact "should index from tarjonta latest"
+  (comment fact "should index from tarjonta latest"
     (let [hk1-oid "1.2.246.562.20.99178639649"
           k1-oid "1.2.246.562.17.81687174185"]
       (with-externals-mock

--- a/test/konfo_indeksoija_service/kouta_indexer_test.clj
+++ b/test/konfo_indeksoija_service/kouta_indexer_test.clj
@@ -136,7 +136,6 @@
 
       (fact "Indexer should index toteutus to toteutus index and update related indexes"
             (check-all-nil)(i/index-toteutus toteutus-oid)
-            (debug-pretty (read toteutus/index-name toteutus-oid))
             (no-timestamp (read toteutus/index-name toteutus-oid)) => (no-timestamp (json "kouta-toteutus-result"))
             (:oid (read search/index-name koulutus-oid)) => koulutus-oid
             (:oid (read koulutus/index-name koulutus-oid)) => koulutus-oid)

--- a/test/konfo_indeksoija_service/kouta_koulutus_search_test.clj
+++ b/test/konfo_indeksoija_service/kouta_koulutus_search_test.clj
@@ -1,0 +1,43 @@
+(ns konfo-indeksoija-service.kouta-koulutus-search-test
+  (:require [midje.sweet :refer :all]
+            [konfo-indeksoija-service.kouta.tools.hakuaika :refer [->real-hakuajat]]))
+
+  (facts "Hakuajat"
+
+    (let [hakuaika1     {:alkaa "2031-04-02T12:00" :paattyy "2031-05-02T12:00"}
+          hakuaika2     {:alkaa "2032-04-02T12:00" :paattyy "2032-05-02T12:00"}
+          hakuaika3     {:alkaa "2033-04-02T12:00" :paattyy "2033-05-02T12:00"}
+          hakuaika4     {:alkaa "2034-04-02T12:00" :paattyy "2034-05-02T12:00"}
+
+          expected1     {:gte "2031-04-02T12:00" :lt "2031-05-02T12:00"}
+          expected2     {:gte "2032-04-02T12:00" :lt "2032-05-02T12:00"}
+          expected3     {:gte "2033-04-02T12:00" :lt "2033-05-02T12:00"}
+          expected4     {:gte "2034-04-02T12:00" :lt "2034-05-02T12:00"}
+
+          haku1         {:hakuajat [hakuaika1, hakuaika2] :hakukohteet []}
+          haku2         {:hakuajat [hakuaika3, hakuaika4] :hakukohteet []}
+          haku          {:hakuajat []                     :hakukohteet []}
+          hakukohde1    {:hakuajat [hakuaika1, hakuaika2] :kaytetaanHaunAikataulua false}
+          hakukohde2    {:hakuajat [hakuaika3]            :kaytetaanHaunAikataulua false}
+          hakukohde3    {:hakuajat [hakuaika4]            :kaytetaanHaunAikataulua false}]
+
+      (fact "should contain hakujen hakuajat"
+        (->real-hakuajat {:haut [haku1, haku2]})
+          => (just [expected1, expected2, expected3, expected4] :in-any-order))
+
+      (fact "should contain hakukohteiden hakuajat"
+        (->real-hakuajat {:haut [(merge haku {:hakukohteet [hakukohde1, hakukohde2]}),
+                                 (merge haku {:hakukohteet [hakukohde3]})]})
+          => (just [expected1, expected2, expected3, expected4] :in-any-order))
+
+      (fact "should ignore haun hakuajat if not used"
+        (->real-hakuajat {:haut [(merge haku1 {:hakukohteet [hakukohde2]})]})
+          => (just [expected3] :in-any-order))
+
+      (fact "should ignore hakukohteen hakuajat if not used"
+        (->real-hakuajat {:haut [(merge haku1 {:hakukohteet [(merge hakukohde2 {:kaytetaanHaunAikataulua true})]})]})
+          => (just [expected1, expected2] :in-any-order))
+
+      (fact "should remove duplicates"
+        (->real-hakuajat {:haut [haku1 (merge haku (:hakukohteet hakukohde1)) haku1]})
+          => (just [expected1, expected2] :in-any-order))))

--- a/test/resources/kouta/kouta-koulutus-search-result.json
+++ b/test/resources/kouta/kouta-koulutus-search-result.json
@@ -1,6 +1,7 @@
 {
   "tila" : "julkaistu",
   "johtaaTutkintoon" : true,
+  "kielivalinta" : ["fi", "sv"],
   "tarjoajat" : [ {
     "paikkakunta" : {
       "koodiUri" : "kunta_091",
@@ -17,6 +18,7 @@
   } ],
   "toteutukset" : [ {
     "tila" : "julkaistu",
+    "kielivalinta" : ["fi", "sv"],
     "tarjoajat" : [{
       "nimi" : {
         "fi" : "Kiva ammattikorkeakoulu, Helsingin toimipiste",
@@ -39,7 +41,6 @@
       "nimi" : "Kalle Ankka"
     },
     "oid" : "1.2.246.562.17.00000000000000000002",
-    "hakuKäynnissä" : false,
     "koulutus" : {
       "tila" : "julkaistu",
       "johtaaTutkintoon" : true,
@@ -71,6 +72,7 @@
       },
       "koulutustyyppi" : "amm"
     },
+    "hakuOnKaynnissa" : [],
     "haut" : [ ],
     "organisaatio" : {
       "paikkakunta" : {
@@ -158,6 +160,7 @@
     }
   }, {
     "tila" : "julkaistu",
+    "kielivalinta" : ["fi", "sv"],
     "tarjoajat" : [ {
       "paikkakunta" : {
         "koodiUri" : "kunta_297",
@@ -182,7 +185,6 @@
       "nimi" : "Kalle Ankka"
     },
     "oid" : "1.2.246.562.17.00000000000000000003",
-    "hakuKäynnissä" : true,
     "koulutus" : {
       "tila" : "julkaistu",
       "johtaaTutkintoon" : true,
@@ -214,6 +216,12 @@
       },
       "koulutustyyppi" : "amm"
     },
+    "hakuOnKaynnissa" : [
+      {
+        "gte" : "2018-10-10T12:00",
+        "lt"  : "2030-11-10T12:00"
+      }
+    ],
     "haut" : [ {
       "hakulomaketyyppi" : "ei sähköistä",
       "alkamiskausi" : {
@@ -275,7 +283,6 @@
         "paattyy" : "2019-11-10T12:00"
       } ],
       "hakuOid" : "1.2.246.562.29.00000000000000000001",
-      "hakuKäynnissä" : true,
       "alkamisvuosi" : "2020",
       "organisaatioOid" : "1.2.246.562.10.54545454545"
     } ],


### PR DESCRIPTION
- oppijan koulutushakua ja rajapintoja varten tehtyjä muutoksia
- laitettu ePerusteiden ja organisaatioiden indeksointi takaisin päälle
- kommentoitu pois vanhan tarjonnan indeksointi (siivotaan paremmin myöhemmin)